### PR TITLE
fix(dependencies): upgrade mocha to v11 and sinon to v19, added engin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Semantic-Release 'Release Notification Plugin' for MS Teams
+
+This plugin can be used for sending a release notification to a MS Teams' Channel.
+
+## How to test
+
+Open a PR and let the respective workflow do that. Check the logs and if you see notifications in the MS Teams' channel.
+You'll find one test notification per test run (corresponds to the number of versions specified in the nodejs version matrix).

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,51 +19,28 @@
             "devDependencies": {
                 "@semantic-release/changelog": "github:semantic-release/changelog",
                 "@semantic-release/git": "github:semantic-release/git",
-                "mocha": "^10.4.0",
+                "mocha": "^11.0.1",
                 "nock": "^13.5.4",
                 "prettier": "^3.2.5",
                 "semantic-release": "^24.0.0",
                 "semantic-release-teams-notify-plugin": "file:./index.js",
-                "sinon": "^17.0.1"
+                "sinon": "^19.0.2"
+            },
+            "engines": {
+                "node": "^21.6.2",
+                "npm": ">=10.2.4"
             }
         },
         "index.js": {
             "dev": true
         },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@babel/code-frame": {
-            "version": "7.24.2",
+            "version": "7.26.2",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/highlight": "^7.24.2",
-                "picocolors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.24.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.24.5",
-                "chalk": "^2.4.2",
+                "@babel/helper-validator-identifier": "^7.25.9",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.0.0"
             },
@@ -71,102 +48,54 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/highlight/node_modules/ansi-styles": {
-            "version": "3.2.1",
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.25.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/chalk": {
-            "version": "2.4.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-convert": {
-            "version": "1.9.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/color-name": {
-            "version": "1.1.3",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/has-flag": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/highlight/node_modules/supports-color": {
-            "version": "5.5.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=0.1.90"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.0",
-            "license": "MIT",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
             "dependencies": {
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.10.0",
-            "license": "MIT",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
             "version": "2.1.4",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -187,7 +116,8 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -195,7 +125,8 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
             "version": "3.1.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -204,17 +135,20 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.57.0",
-            "license": "MIT",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.14",
-            "license": "Apache-2.0",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+            "deprecated": "Use @eslint/config-array instead",
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.2",
+                "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
@@ -224,7 +158,8 @@
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -232,7 +167,8 @@
         },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
             "version": "3.1.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -242,7 +178,8 @@
         },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+            "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "engines": {
                 "node": ">=12.22"
             },
@@ -252,12 +189,32 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.2",
-            "license": "BSD-3-Clause"
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+            "deprecated": "Use @eslint/object-schema instead"
+        },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -268,14 +225,16 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -286,22 +245,24 @@
         },
         "node_modules/@octokit/auth-token": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+            "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "6.1.2",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.3.tgz",
+            "integrity": "sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@octokit/auth-token": "^5.0.0",
-                "@octokit/graphql": "^8.0.0",
-                "@octokit/request": "^9.0.0",
-                "@octokit/request-error": "^6.0.1",
-                "@octokit/types": "^13.0.0",
+                "@octokit/graphql": "^8.1.2",
+                "@octokit/request": "^9.1.4",
+                "@octokit/request-error": "^6.1.6",
+                "@octokit/types": "^13.6.2",
                 "before-after-hook": "^3.0.2",
                 "universal-user-agent": "^7.0.0"
             },
@@ -310,11 +271,12 @@
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "10.1.1",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.2.tgz",
+            "integrity": "sha512-XybpFv9Ms4hX5OCHMZqyODYqGTZ3H6K6Vva+M9LR7ib/xr1y1ZnlChYv9H680y77Vd/i/k+thXApeRASBQkzhA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.0.0",
+                "@octokit/types": "^13.6.2",
                 "universal-user-agent": "^7.0.2"
             },
             "engines": {
@@ -322,12 +284,13 @@
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "8.1.1",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.2.tgz",
+            "integrity": "sha512-bdlj/CJVjpaz06NBpfHhp4kGJaRZfz7AzC+6EwUImRtrwIw8dIgJ63Xg0OzV9pRn3rIzrt5c2sa++BL0JJ8GLw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/request": "^9.0.0",
-                "@octokit/types": "^13.0.0",
+                "@octokit/request": "^9.1.4",
+                "@octokit/types": "^13.6.2",
                 "universal-user-agent": "^7.0.0"
             },
             "engines": {
@@ -335,16 +298,18 @@
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "22.2.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "23.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+            "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+            "dev": true
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "11.3.0",
+            "version": "11.4.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.0.tgz",
+            "integrity": "sha512-ttpGck5AYWkwMkMazNCZMqxKqIq1fJBNxBfsFwwfyYKTf914jKkLF0POMS3YkPBwp5g1c2Y4L79gDz01GhSr1g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.5.0"
+                "@octokit/types": "^13.7.0"
             },
             "engines": {
                 "node": ">= 18"
@@ -354,12 +319,13 @@
             }
         },
         "node_modules/@octokit/plugin-retry": {
-            "version": "7.1.1",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.3.tgz",
+            "integrity": "sha512-8nKOXvYWnzv89gSyIvgFHmCBAxfQAOPRlkacUHL9r5oWtp5Whxl8Skb2n3ACZd+X6cYijD6uvmrQuPH/UCL5zQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/request-error": "^6.0.0",
-                "@octokit/types": "^13.0.0",
+                "@octokit/request-error": "^6.1.6",
+                "@octokit/types": "^13.6.2",
                 "bottleneck": "^2.15.3"
             },
             "engines": {
@@ -370,28 +336,31 @@
             }
         },
         "node_modules/@octokit/plugin-throttling": {
-            "version": "9.3.0",
+            "version": "9.4.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.4.0.tgz",
+            "integrity": "sha512-IOlXxXhZA4Z3m0EEYtrrACkuHiArHLZ3CvqWwOez/pURNqRuwfoFlTPbN5Muf28pzFuztxPyiUiNwz8KctdZaQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.0.0",
+                "@octokit/types": "^13.7.0",
                 "bottleneck": "^2.15.3"
             },
             "engines": {
                 "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": "^6.0.0"
+                "@octokit/core": "^6.1.3"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "9.1.1",
+            "version": "9.1.4",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.4.tgz",
+            "integrity": "sha512-tMbOwGm6wDII6vygP3wUVqFTw3Aoo0FnVQyhihh8vVq12uO3P+vQZeo2CKMpWtPSogpACD0yyZAlVlQnjW71DA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@octokit/endpoint": "^10.0.0",
                 "@octokit/request-error": "^6.0.1",
-                "@octokit/types": "^13.1.0",
+                "@octokit/types": "^13.6.2",
+                "fast-content-type-parse": "^2.0.0",
                 "universal-user-agent": "^7.0.2"
             },
             "engines": {
@@ -399,36 +368,50 @@
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "6.1.1",
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.6.tgz",
+            "integrity": "sha512-pqnVKYo/at0NuOjinrgcQYpEbv4snvP3bKMRqHaD9kIsk9u1LCpb2smHZi8/qJfgeNqLo5hNW4Z7FezNdEo0xg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^13.0.0"
+                "@octokit/types": "^13.6.2"
             },
             "engines": {
                 "node": ">= 18"
             }
         },
         "node_modules/@octokit/types": {
-            "version": "13.5.0",
+            "version": "13.7.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.7.0.tgz",
+            "integrity": "sha512-BXfRP+3P3IN6fd4uF3SniaHKOO4UXWBfkdR3vA8mIvaoO/wLjGN5qivUtW0QRitBHHMcfC41SLhNVYIZZE+wkA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^22.2.0"
+                "@octokit/openapi-types": "^23.0.1"
+            }
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
+            "optional": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/@pnpm/config.env-replace": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+            "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12.22.0"
             }
         },
         "node_modules/@pnpm/network.ca-file": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "4.2.10"
             },
@@ -438,13 +421,15 @@
         },
         "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
             "version": "4.2.10",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+            "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+            "dev": true
         },
         "node_modules/@pnpm/npm-conf": {
-            "version": "2.2.2",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.3.1.tgz",
+            "integrity": "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@pnpm/config.env-replace": "^1.1.0",
                 "@pnpm/network.ca-file": "^1.0.1",
@@ -456,13 +441,15 @@
         },
         "node_modules/@sec-ant/readable-stream": {
             "version": "0.4.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+            "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+            "dev": true
         },
         "node_modules/@semantic-release/changelog": {
             "version": "0.0.0-development",
             "resolved": "git+ssh://git@github.com/semantic-release/changelog.git#1c480009c182a1f3d0e27bf6bf01797bb24345e7",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@semantic-release/error": "^3.0.0",
                 "aggregate-error": "^3.0.0",
@@ -478,16 +465,18 @@
         },
         "node_modules/@semantic-release/changelog/node_modules/@semantic-release/error": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+            "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.17"
             }
         },
         "node_modules/@semantic-release/changelog/node_modules/aggregate-error": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -498,31 +487,34 @@
         },
         "node_modules/@semantic-release/changelog/node_modules/clean-stack": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@semantic-release/changelog/node_modules/indent-string": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/@semantic-release/commit-analyzer": {
-            "version": "13.0.0",
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.1.tgz",
+            "integrity": "sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "conventional-changelog-angular": "^8.0.0",
                 "conventional-changelog-writer": "^8.0.0",
                 "conventional-commits-filter": "^5.0.0",
                 "conventional-commits-parser": "^6.0.0",
                 "debug": "^4.0.0",
-                "import-from-esm": "^1.0.3",
+                "import-from-esm": "^2.0.0",
                 "lodash-es": "^4.17.21",
                 "micromatch": "^4.0.2"
             },
@@ -535,7 +527,8 @@
         },
         "node_modules/@semantic-release/error": {
             "version": "4.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+            "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
             "engines": {
                 "node": ">=18"
             }
@@ -544,6 +537,7 @@
             "version": "0.0.0-development",
             "resolved": "git+ssh://git@github.com/semantic-release/git.git#28a17512def11a1dfbb21836c6061e7179dc0dc2",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@semantic-release/error": "^3.0.0",
                 "aggregate-error": "^3.0.0",
@@ -563,16 +557,18 @@
         },
         "node_modules/@semantic-release/git/node_modules/@semantic-release/error": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+            "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.17"
             }
         },
         "node_modules/@semantic-release/git/node_modules/aggregate-error": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "clean-stack": "^2.0.0",
                 "indent-string": "^4.0.0"
@@ -583,119 +579,27 @@
         },
         "node_modules/@semantic-release/git/node_modules/clean-stack": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/execa": {
-            "version": "5.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/human-signals": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=10.17.0"
             }
         },
         "node_modules/@semantic-release/git/node_modules/indent-string": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/is-stream": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/onetime": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/p-reduce": {
-            "version": "2.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@semantic-release/git/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/@semantic-release/git/node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/@semantic-release/github": {
-            "version": "10.0.3",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-11.0.1.tgz",
+            "integrity": "sha512-Z9cr0LgU/zgucbT9cksH0/pX9zmVda9hkDPcgIE0uvjMQ8w/mElDivGjx1w1pEQ+MuQJ5CBq3VCF16S6G4VH3A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@octokit/core": "^6.0.0",
                 "@octokit/plugin-paginate-rest": "^11.0.0",
@@ -718,17 +622,18 @@
                 "node": ">=20.8.1"
             },
             "peerDependencies": {
-                "semantic-release": ">=20.1.0"
+                "semantic-release": ">=24.1.0"
             }
         },
         "node_modules/@semantic-release/npm": {
-            "version": "12.0.0",
+            "version": "12.0.1",
+            "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
+            "integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@semantic-release/error": "^4.0.0",
                 "aggregate-error": "^5.0.0",
-                "execa": "^8.0.0",
+                "execa": "^9.0.0",
                 "fs-extra": "^11.0.0",
                 "lodash-es": "^4.17.21",
                 "nerf-dart": "^1.0.0",
@@ -747,10 +652,162 @@
                 "semantic-release": ">=20.1.0"
             }
         },
-        "node_modules/@semantic-release/release-notes-generator": {
-            "version": "14.0.0",
+        "node_modules/@semantic-release/npm/node_modules/@sindresorhus/merge-streams": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/execa": {
+            "version": "9.5.2",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+            "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+            "dev": true,
+            "dependencies": {
+                "@sindresorhus/merge-streams": "^4.0.0",
+                "cross-spawn": "^7.0.3",
+                "figures": "^6.1.0",
+                "get-stream": "^9.0.0",
+                "human-signals": "^8.0.0",
+                "is-plain-obj": "^4.1.0",
+                "is-stream": "^4.0.1",
+                "npm-run-path": "^6.0.0",
+                "pretty-ms": "^9.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^4.0.0",
+                "yoctocolors": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.5.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/get-stream": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+            "dev": true,
+            "dependencies": {
+                "@sec-ant/readable-stream": "^0.4.1",
+                "is-stream": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/human-signals": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+            "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/is-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/npm/node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@semantic-release/release-notes-generator": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.0.3.tgz",
+            "integrity": "sha512-XxAZRPWGwO5JwJtS83bRdoIhCiYIx8Vhr+u231pQAsdFIAbm19rSVJLdnBN+Avvk7CKvNQE/nJ4y7uqKH6WTiw==",
+            "dev": true,
             "dependencies": {
                 "conventional-changelog-angular": "^8.0.0",
                 "conventional-changelog-writer": "^8.0.0",
@@ -758,10 +815,10 @@
                 "conventional-commits-parser": "^6.0.0",
                 "debug": "^4.0.0",
                 "get-stream": "^7.0.0",
-                "import-from-esm": "^1.0.3",
+                "import-from-esm": "^2.0.0",
                 "into-stream": "^7.0.0",
                 "lodash-es": "^4.17.21",
-                "read-pkg-up": "^11.0.0"
+                "read-package-up": "^11.0.0"
             },
             "engines": {
                 "node": ">=20.8.1"
@@ -772,8 +829,9 @@
         },
         "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
             "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+            "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=16"
             },
@@ -783,8 +841,9 @@
         },
         "node_modules/@sindresorhus/is": {
             "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+            "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -794,8 +853,9 @@
         },
         "node_modules/@sindresorhus/merge-streams": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -805,60 +865,69 @@
         },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "type-detect": "4.0.8"
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "11.2.2",
+            "version": "13.0.5",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+            "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
+                "@sinonjs/commons": "^3.0.1"
             }
         },
         "node_modules/@sinonjs/samsam": {
-            "version": "8.0.0",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+            "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
-                "@sinonjs/commons": "^2.0.0",
+                "@sinonjs/commons": "^3.0.1",
                 "lodash.get": "^4.4.2",
-                "type-detect": "^4.0.8"
+                "type-detect": "^4.1.0"
             }
         },
-        "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-            "version": "2.0.0",
+        "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+            "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "type-detect": "4.0.8"
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@sinonjs/text-encoding": {
-            "version": "0.7.2",
-            "dev": true,
-            "license": "(Unlicense OR Apache-2.0)"
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+            "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
+            "dev": true
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+            "dev": true
         },
         "node_modules/@types/semver": {
             "version": "7.5.8",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+            "dev": true
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.2.0",
-            "license": "ISC"
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+            "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA=="
         },
         "node_modules/acorn": {
-            "version": "8.11.3",
-            "license": "MIT",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -868,25 +937,25 @@
         },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.1",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4"
-            },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/aggregate-error": {
             "version": "5.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+            "integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
             "dependencies": {
                 "clean-stack": "^5.2.0",
                 "indent-string": "^5.0.0"
@@ -900,7 +969,8 @@
         },
         "node_modules/ajv": {
             "version": "6.12.6",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -913,34 +983,45 @@
             }
         },
         "node_modules/ansi-colors": {
-            "version": "4.1.1",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "6.2.1",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
             "engines": {
-                "node": ">=14.16"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "license": "MIT",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -953,13 +1034,15 @@
         },
         "node_modules/any-promise": {
             "version": "1.3.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -970,81 +1053,37 @@
         },
         "node_modules/argparse": {
             "version": "2.0.1",
-            "license": "Python-2.0"
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "node_modules/argv-formatter": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/array-buffer-byte-length": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "is-array-buffer": "^3.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+            "integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
+            "dev": true
         },
         "node_modules/array-ify": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.1",
-                "call-bind": "^1.0.5",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.22.3",
-                "es-errors": "^1.2.1",
-                "get-intrinsic": "^1.2.3",
-                "is-array-buffer": "^3.0.4",
-                "is-shared-array-buffer": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+            "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+            "dev": true
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/before-after-hook": {
             "version": "3.0.2",
-            "dev": true,
-            "license": "Apache-2.0"
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+            "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+            "dev": true
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -1054,13 +1093,15 @@
         },
         "node_modules/bottleneck": {
             "version": "2.19.5",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+            "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+            "dev": true
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -1078,38 +1119,23 @@
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/call-bind": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "set-function-length": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true
         },
         "node_modules/callsites": {
             "version": "3.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/camelcase": {
             "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -1119,7 +1145,8 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -1131,24 +1158,31 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/char-regex": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+            "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
-            "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -1161,13 +1195,17 @@
             "engines": {
                 "node": ">= 8.10.0"
             },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
             }
         },
         "node_modules/clean-stack": {
             "version": "5.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+            "integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
             "dependencies": {
                 "escape-string-regexp": "5.0.0"
             },
@@ -1178,20 +1216,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/clean-stack/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/cli-highlight": {
             "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+            "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "chalk": "^4.0.0",
                 "highlight.js": "^10.7.1",
@@ -1209,9 +1238,10 @@
             }
         },
         "node_modules/cli-table3": {
-            "version": "0.6.4",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "string-width": "^4.2.0"
             },
@@ -1222,19 +1252,120 @@
                 "@colors/colors": "1.5.0"
             }
         },
+        "node_modules/cli-table3/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/cli-table3/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cli-table3/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cliui": {
             "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -1244,12 +1375,14 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "node_modules/compare-func": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "array-ify": "^1.0.0",
                 "dot-prop": "^5.1.0"
@@ -1257,12 +1390,14 @@
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
         },
         "node_modules/config-chain": {
             "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -1270,8 +1405,9 @@
         },
         "node_modules/conventional-changelog-angular": {
             "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+            "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "compare-func": "^2.0.0"
             },
@@ -1281,8 +1417,9 @@
         },
         "node_modules/conventional-changelog-writer": {
             "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.0.tgz",
+            "integrity": "sha512-TQcoYGRatlAnT2qEWDON/XSfnVG38JzA7E0wcGScu7RElQBkg9WWgZd1peCWFcWDh1xfb2CfsrcvOn1bbSzztA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/semver": "^7.5.5",
                 "conventional-commits-filter": "^5.0.0",
@@ -1299,16 +1436,18 @@
         },
         "node_modules/conventional-commits-filter": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+            "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/conventional-commits-parser": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.0.0.tgz",
+            "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "meow": "^13.0.0"
             },
@@ -1321,8 +1460,9 @@
         },
         "node_modules/convert-hrtime": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+            "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -1332,13 +1472,15 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "node_modules/cosmiconfig": {
             "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -1361,8 +1503,9 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "license": "MIT",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -1374,8 +1517,9 @@
         },
         "node_modules/crypto-random-string": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+            "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "type-fest": "^1.0.1"
             },
@@ -1388,8 +1532,9 @@
         },
         "node_modules/crypto-random-string/node_modules/type-fest": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
             },
@@ -1399,64 +1544,18 @@
         },
         "node_modules/data-uri-to-buffer": {
             "version": "4.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+            "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
             "engines": {
                 "node": ">= 12"
             }
         },
-        "node_modules/data-view-buffer": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/data-view-byte-length": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/data-view-byte-offset": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "license": "MIT",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -1467,14 +1566,11 @@
                 }
             }
         },
-        "node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "license": "MIT"
-        },
         "node_modules/decamelize": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -1484,60 +1580,32 @@
         },
         "node_modules/deep-extend": {
             "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
-            "license": "MIT"
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
         },
         "node_modules/diff": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
             }
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -1547,7 +1615,8 @@
         },
         "node_modules/doctrine": {
             "version": "3.0.0",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -1557,8 +1626,9 @@
         },
         "node_modules/dot-prop": {
             "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+            "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-obj": "^2.0.0"
             },
@@ -1568,26 +1638,36 @@
         },
         "node_modules/duplexer2": {
             "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "readable-stream": "^2.0.2"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true
+        },
         "node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true
         },
         "node_modules/emojilib": {
             "version": "2.4.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+            "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+            "dev": true
         },
         "node_modules/env-ci": {
-            "version": "11.0.0",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.1.0.tgz",
+            "integrity": "sha512-Z8dnwSDbV1XYM9SBF2J0GcNVvmfmfh3a49qddGIROhBoVro6MZVTji15z/sJbQ2ko2ei8n988EU1wzoLU/tF+g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "execa": "^8.0.0",
                 "java-properties": "^1.0.2"
@@ -1596,167 +1676,201 @@
                 "node": "^18.17 || >=20.6.1"
             }
         },
+        "node_modules/env-ci/node_modules/execa": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+            "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^8.0.1",
+                "human-signals": "^5.0.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^4.1.0",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=16.17"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/env-ci/node_modules/get-stream": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+            "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/human-signals": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+            "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16.17.0"
+            }
+        },
+        "node_modules/env-ci/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/npm-run-path": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+            "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/env-ci/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/env-ci/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/env-paths": {
             "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/error-ex": {
             "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
         },
-        "node_modules/es-abstract": {
-            "version": "1.23.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.1",
-                "arraybuffer.prototype.slice": "^1.0.3",
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "data-view-buffer": "^1.0.1",
-                "data-view-byte-length": "^1.0.1",
-                "data-view-byte-offset": "^1.0.0",
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
-                "es-set-tostringtag": "^2.0.3",
-                "es-to-primitive": "^1.2.1",
-                "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.4",
-                "get-symbol-description": "^1.0.2",
-                "globalthis": "^1.0.3",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2",
-                "has-proto": "^1.0.3",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.2",
-                "internal-slot": "^1.0.7",
-                "is-array-buffer": "^3.0.4",
-                "is-callable": "^1.2.7",
-                "is-data-view": "^1.0.1",
-                "is-negative-zero": "^2.0.3",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.3",
-                "is-string": "^1.0.7",
-                "is-typed-array": "^1.1.13",
-                "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.5",
-                "regexp.prototype.flags": "^1.5.2",
-                "safe-array-concat": "^1.1.2",
-                "safe-regex-test": "^1.0.3",
-                "string.prototype.trim": "^1.2.9",
-                "string.prototype.trimend": "^1.0.8",
-                "string.prototype.trimstart": "^1.0.8",
-                "typed-array-buffer": "^1.0.2",
-                "typed-array-byte-length": "^1.0.1",
-                "typed-array-byte-offset": "^1.0.2",
-                "typed-array-length": "^1.0.6",
-                "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.15"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-to-primitive": {
-            "version": "1.2.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/escalade": {
-            "version": "3.1.2",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/escape-string-regexp": {
-            "version": "4.0.0",
-            "license": "MIT",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint": {
-            "version": "8.57.0",
-            "license": "MIT",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.57.0",
-                "@humanwhocodes/config-array": "^0.11.14",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -1803,7 +1917,8 @@
         },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -1817,7 +1932,8 @@
         },
         "node_modules/eslint-visitor-keys": {
             "version": "3.4.3",
-            "license": "Apache-2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -1825,17 +1941,38 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/eslint/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/eslint/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/eslint/node_modules/glob-parent": {
             "version": "6.0.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -1845,7 +1982,8 @@
         },
         "node_modules/eslint/node_modules/minimatch": {
             "version": "3.1.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -1853,9 +1991,21 @@
                 "node": "*"
             }
         },
+        "node_modules/eslint/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/espree": {
             "version": "9.6.1",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -1869,8 +2019,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.5.0",
-            "license": "BSD-3-Clause",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -1880,7 +2031,8 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -1890,65 +2042,75 @@
         },
         "node_modules/estraverse": {
             "version": "5.3.0",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "engines": {
                 "node": ">=4.0"
             }
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/execa": {
-            "version": "8.0.1",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cross-spawn": "^7.0.3",
-                "get-stream": "^8.0.1",
-                "human-signals": "^5.0.0",
-                "is-stream": "^3.0.0",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
                 "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^4.1.0",
-                "strip-final-newline": "^3.0.0"
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
             },
             "engines": {
-                "node": ">=16.17"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
             }
         },
-        "node_modules/execa/node_modules/get-stream": {
-            "version": "8.0.1",
+        "node_modules/fast-content-type-parse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+            "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
             "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "node_modules/fast-glob": {
-            "version": "3.3.2",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -1956,21 +2118,26 @@
         },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
         },
         "node_modules/fastq": {
-            "version": "1.17.1",
-            "license": "ISC",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+            "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
         },
         "node_modules/fetch-blob": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+            "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
             "funding": [
                 {
                     "type": "github",
@@ -1981,7 +2148,6 @@
                     "url": "https://paypal.me/jimmywarting"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "node-domexception": "^1.0.0",
                 "web-streams-polyfill": "^3.0.3"
@@ -1992,8 +2158,9 @@
         },
         "node_modules/figures": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+            "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-unicode-supported": "^2.0.0"
             },
@@ -2005,9 +2172,10 @@
             }
         },
         "node_modules/figures/node_modules/is-unicode-supported": {
-            "version": "2.0.0",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+            "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2017,7 +2185,8 @@
         },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -2038,7 +2207,8 @@
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -2052,8 +2222,9 @@
         },
         "node_modules/find-up-simple": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+            "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2063,8 +2234,9 @@
         },
         "node_modules/find-versions": {
             "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+            "integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "semver-regex": "^4.0.5",
                 "super-regex": "^1.0.0"
@@ -2078,15 +2250,17 @@
         },
         "node_modules/flat": {
             "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "bin": {
                 "flat": "cli.js"
             }
         },
         "node_modules/flat-cache": {
             "version": "3.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -2097,20 +2271,42 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "license": "ISC"
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA=="
         },
-        "node_modules/for-each": {
-            "version": "0.3.3",
+        "node_modules/foreground-child": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+            "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "is-callable": "^1.1.3"
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/formdata-polyfill": {
             "version": "4.0.10",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
             "dependencies": {
                 "fetch-blob": "^3.1.2"
             },
@@ -2120,8 +2316,9 @@
         },
         "node_modules/from2": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.1",
                 "readable-stream": "^2.0.0"
@@ -2129,8 +2326,9 @@
         },
         "node_modules/fs-extra": {
             "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -2142,20 +2340,28 @@
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/function-timeout": {
-            "version": "1.0.1",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+            "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2163,61 +2369,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/function.prototype.name": {
-            "version": "1.1.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "functions-have-names": "^1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
             }
         },
-        "node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-stream": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -2225,56 +2390,35 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/get-symbol-description": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/git-log-parser": {
-            "version": "1.2.0",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
+            "integrity": "sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "argv-formatter": "~1.0.0",
                 "spawn-error-forwarder": "~1.0.0",
                 "split2": "~1.0.0",
                 "stream-combiner2": "~1.1.1",
                 "through2": "~2.0.0",
-                "traverse": "~0.6.6"
-            }
-        },
-        "node_modules/git-log-parser/node_modules/split2": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "through2": "~2.0.0"
+                "traverse": "0.6.8"
             }
         },
         "node_modules/glob": {
-            "version": "8.1.0",
+            "version": "10.4.5",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
-            "engines": {
-                "node": ">=12"
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -2282,8 +2426,9 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -2291,9 +2436,25 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/globals": {
             "version": "13.24.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -2304,25 +2465,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/globalthis": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/globby": {
-            "version": "14.0.1",
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
+            "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^2.1.0",
                 "fast-glob": "^3.3.2",
@@ -2340,8 +2487,9 @@
         },
         "node_modules/globby/node_modules/path-type": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+            "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -2349,30 +2497,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/gopd": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "node_modules/graphemer": {
             "version": "1.4.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
         },
         "node_modules/handlebars": {
             "version": "4.7.8",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.5",
                 "neo-async": "^2.6.2",
@@ -2389,99 +2529,37 @@
                 "uglify-js": "^3.1.4"
             }
         },
-        "node_modules/has-bigints": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/he": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "he": "bin/he"
             }
         },
         "node_modules/highlight.js": {
             "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": "*"
             }
         },
         "node_modules/hook-std": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+            "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -2490,20 +2568,22 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "7.0.1",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.2.tgz",
+            "integrity": "sha512-sYKnA7eGln5ov8T8gnYlkSOxFJvywzEx9BueN6xo/GKO8PGiI6uK6xx+DIGe45T3bdVjLAQDQW1aicT8z8JwQg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "lru-cache": "^10.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -2513,11 +2593,12 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.4",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "agent-base": "^7.0.2",
+                "agent-base": "^7.1.2",
                 "debug": "4"
             },
             "engines": {
@@ -2525,23 +2606,26 @@
             }
         },
         "node_modules/human-signals": {
-            "version": "5.0.0",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
-                "node": ">=16.17.0"
+                "node": ">=10.17.0"
             }
         },
         "node_modules/ignore": {
-            "version": "5.3.1",
-            "license": "MIT",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "engines": {
                 "node": ">= 4"
             }
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -2554,21 +2638,23 @@
             }
         },
         "node_modules/import-from-esm": {
-            "version": "1.3.4",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-2.0.0.tgz",
+            "integrity": "sha512-YVt14UZCgsX1vZQ3gKjkWVdBdHQ6eu3MPU1TBgL1H5orXe2+jWD006WCPPtOuwlQm10NuzOW5WawiF1Q9veW8g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4",
                 "import-meta-resolve": "^4.0.0"
             },
             "engines": {
-                "node": ">=16.20"
+                "node": ">=18.20"
             }
         },
         "node_modules/import-meta-resolve": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+            "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -2576,14 +2662,16 @@
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "engines": {
                 "node": ">=0.8.19"
             }
         },
         "node_modules/indent-string": {
             "version": "5.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
             "engines": {
                 "node": ">=12"
             },
@@ -2593,8 +2681,9 @@
         },
         "node_modules/index-to-position": {
             "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+            "integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -2604,7 +2693,9 @@
         },
         "node_modules/inflight": {
             "version": "1.0.6",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -2612,30 +2703,20 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ini": {
             "version": "1.3.8",
-            "dev": true,
-            "license": "ISC"
-        },
-        "node_modules/internal-slot": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true
         },
         "node_modules/into-stream": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
+            "integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "from2": "^2.3.0",
                 "p-is-promise": "^3.0.0"
@@ -2647,41 +2728,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-array-buffer": {
-            "version": "3.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/is-bigint": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-bigints": "^1.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "dev": true
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
             },
@@ -2689,105 +2746,32 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-boolean-object": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.13.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-data-view": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-negative-zero": {
-            "version": "2.0.3",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-number": {
@@ -2798,129 +2782,49 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-number-object": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-obj": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+            "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/is-plain-obj": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/is-regex": {
-            "version": "1.1.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-shared-array-buffer": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-stream": {
-            "version": "3.0.0",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-string": {
-            "version": "1.0.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-symbol": {
-            "version": "1.0.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.13",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "which-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -2928,30 +2832,22 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-weakref": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/isarray": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
         },
         "node_modules/issue-parser": {
-            "version": "7.0.0",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
+            "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "lodash.capitalize": "^4.2.1",
                 "lodash.escaperegexp": "^4.1.2",
@@ -2963,22 +2859,40 @@
                 "node": "^18.17 || >=20.6.1"
             }
         },
+        "node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "dev": true,
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/java-properties": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+            "integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.6.0"
             }
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -2988,35 +2902,42 @@
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
         },
         "node_modules/json-parse-better-errors": {
             "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
         },
         "node_modules/json-stringify-safe": {
             "version": "5.0.1",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -3026,19 +2947,22 @@
         },
         "node_modules/just-extend": {
             "version": "6.2.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+            "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+            "dev": true
         },
         "node_modules/keyv": {
             "version": "4.5.4",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+            "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
         },
         "node_modules/levn": {
             "version": "0.4.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -3049,13 +2973,15 @@
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true
         },
         "node_modules/load-json-file": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "parse-json": "^4.0.0",
@@ -3068,8 +2994,9 @@
         },
         "node_modules/load-json-file/node_modules/parse-json": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "error-ex": "^1.3.1",
                 "json-parse-better-errors": "^1.0.1"
@@ -3080,7 +3007,8 @@
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -3093,51 +3021,61 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+            "dev": true
         },
         "node_modules/lodash.capitalize": {
             "version": "4.2.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+            "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+            "dev": true
         },
         "node_modules/lodash.escaperegexp": {
             "version": "4.1.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+            "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+            "dev": true
         },
         "node_modules/lodash.get": {
             "version": "4.4.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+            "dev": true
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true
         },
         "node_modules/lodash.isstring": {
             "version": "4.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "dev": true
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "node_modules/lodash.uniqby": {
             "version": "4.7.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+            "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+            "dev": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
@@ -3150,17 +3088,16 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "10.2.2",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "14 || >=16.14"
-            }
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true
         },
         "node_modules/marked": {
             "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+            "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -3169,28 +3106,31 @@
             }
         },
         "node_modules/marked-terminal": {
-            "version": "7.0.0",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.2.1.tgz",
+            "integrity": "sha512-rQ1MoMFXZICWNsKMiiHwP/Z+92PLKskTPXj+e7uwXmuMPkNn7iTqC+IvDekVm1MPeC9wYQeLxeFaOvudRR/XbQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "ansi-escapes": "^6.2.0",
+                "ansi-escapes": "^7.0.0",
+                "ansi-regex": "^6.1.0",
                 "chalk": "^5.3.0",
                 "cli-highlight": "^2.1.11",
-                "cli-table3": "^0.6.3",
+                "cli-table3": "^0.6.5",
                 "node-emoji": "^2.1.3",
-                "supports-hyperlinks": "^3.0.0"
+                "supports-hyperlinks": "^3.1.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             },
             "peerDependencies": {
-                "marked": ">=1 <13"
+                "marked": ">=1 <15"
             }
         },
         "node_modules/marked-terminal/node_modules/chalk": {
-            "version": "5.3.0",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.17.0 || ^14.13 || >=16.0.0"
             },
@@ -3200,8 +3140,9 @@
         },
         "node_modules/meow": {
             "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -3211,13 +3152,15 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
         },
         "node_modules/merge2": {
             "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -3235,12 +3178,13 @@
             }
         },
         "node_modules/mime": {
-            "version": "4.0.3",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.6.tgz",
+            "integrity": "sha512-4rGt7rvQHBbaSOF9POGkk1ocRP16Md1x36Xma8sz8h8/vfCUI2OtEIeCqe4Ofes853x4xDoPiFLIT47J5fI/7A==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/broofa"
             ],
-            "license": "MIT",
             "bin": {
                 "mime": "bin/cli.js"
             },
@@ -3249,20 +3193,19 @@
             }
         },
         "node_modules/mimic-fn": {
-            "version": "4.0.0",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
-            "version": "5.0.1",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -3272,77 +3215,79 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true,
-            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/mocha": {
-            "version": "10.4.0",
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.0.1.tgz",
+            "integrity": "sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==",
+            "dev": true,
             "dependencies": {
-                "ansi-colors": "4.1.1",
-                "browser-stdout": "1.3.1",
-                "chokidar": "3.5.3",
-                "debug": "4.3.4",
-                "diff": "5.0.0",
-                "escape-string-regexp": "4.0.0",
-                "find-up": "5.0.0",
-                "glob": "8.1.0",
-                "he": "1.2.0",
-                "js-yaml": "4.1.0",
-                "log-symbols": "4.1.0",
-                "minimatch": "5.0.1",
-                "ms": "2.1.3",
-                "serialize-javascript": "6.0.0",
-                "strip-json-comments": "3.1.1",
-                "supports-color": "8.1.1",
-                "workerpool": "6.2.1",
-                "yargs": "16.2.0",
-                "yargs-parser": "20.2.4",
-                "yargs-unparser": "2.0.0"
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^10.4.5",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
             },
             "bin": {
                 "_mocha": "bin/_mocha",
                 "mocha": "bin/mocha.js"
             },
             "engines": {
-                "node": ">= 14.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/mocha/node_modules/diff": {
-            "version": "5.0.0",
+        "node_modules/mocha/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/mocha/node_modules/supports-color": {
-            "version": "8.1.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
             "engines": {
                 "node": ">=10"
             },
             "funding": {
-                "url": "https://github.com/chalk/supports-color?sponsor=1"
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/mz": {
             "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0",
                 "object-assign": "^4.0.1",
@@ -3351,34 +3296,39 @@
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+            "dev": true
         },
         "node_modules/nerf-dart": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+            "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+            "dev": true
         },
         "node_modules/nise": {
-            "version": "5.1.9",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
+            "integrity": "sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
-                "@sinonjs/commons": "^3.0.0",
-                "@sinonjs/fake-timers": "^11.2.2",
-                "@sinonjs/text-encoding": "^0.7.2",
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^13.0.1",
+                "@sinonjs/text-encoding": "^0.7.3",
                 "just-extend": "^6.2.0",
-                "path-to-regexp": "^6.2.1"
+                "path-to-regexp": "^8.1.0"
             }
         },
         "node_modules/nock": {
-            "version": "13.5.4",
+            "version": "13.5.6",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+            "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "debug": "^4.1.0",
                 "json-stringify-safe": "^5.0.1",
@@ -3390,6 +3340,8 @@
         },
         "node_modules/node-domexception": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
             "funding": [
                 {
                     "type": "github",
@@ -3400,15 +3352,15 @@
                     "url": "https://paypal.me/jimmywarting"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=10.5.0"
             }
         },
         "node_modules/node-emoji": {
-            "version": "2.1.3",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+            "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/is": "^4.6.0",
                 "char-regex": "^1.0.2",
@@ -3421,7 +3373,8 @@
         },
         "node_modules/node-fetch": {
             "version": "3.3.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+            "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
             "dependencies": {
                 "data-uri-to-buffer": "^4.0.0",
                 "fetch-blob": "^3.1.4",
@@ -3436,12 +3389,12 @@
             }
         },
         "node_modules/normalize-package-data": {
-            "version": "6.0.0",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+            "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "hosted-git-info": "^7.0.0",
-                "is-core-module": "^2.8.1",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4"
             },
@@ -3449,18 +3402,32 @@
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
+        "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+            "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^10.0.1"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/normalize-url": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+            "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -3469,7 +3436,9 @@
             }
         },
         "node_modules/npm": {
-            "version": "10.7.0",
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.2.tgz",
+            "integrity": "sha512-iriPEPIkoMYUy3F6f3wwSZAU93E0Eg6cHwIR6jzzOXWSy+SD/rOODEs74cVONHKSx2obXtuUoyidVEhISrisgQ==",
             "bundleDependencies": [
                 "@isaacs/string-locale-compare",
                 "@npmcli/arborist",
@@ -3541,83 +3510,75 @@
                 "write-file-atomic"
             ],
             "dev": true,
-            "license": "Artistic-2.0",
-            "workspaces": [
-                "docs",
-                "smoke-tests",
-                "mock-globals",
-                "mock-registry",
-                "workspaces/*"
-            ],
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/arborist": "^7.2.1",
-                "@npmcli/config": "^8.0.2",
-                "@npmcli/fs": "^3.1.0",
-                "@npmcli/map-workspaces": "^3.0.6",
-                "@npmcli/package-json": "^5.1.0",
-                "@npmcli/promise-spawn": "^7.0.1",
-                "@npmcli/redact": "^2.0.0",
-                "@npmcli/run-script": "^8.1.0",
-                "@sigstore/tuf": "^2.3.2",
-                "abbrev": "^2.0.0",
+                "@npmcli/arborist": "^8.0.0",
+                "@npmcli/config": "^9.0.0",
+                "@npmcli/fs": "^4.0.0",
+                "@npmcli/map-workspaces": "^4.0.2",
+                "@npmcli/package-json": "^6.1.0",
+                "@npmcli/promise-spawn": "^8.0.2",
+                "@npmcli/redact": "^3.0.0",
+                "@npmcli/run-script": "^9.0.1",
+                "@sigstore/tuf": "^3.0.0",
+                "abbrev": "^3.0.0",
                 "archy": "~1.0.0",
-                "cacache": "^18.0.2",
+                "cacache": "^19.0.1",
                 "chalk": "^5.3.0",
-                "ci-info": "^4.0.0",
+                "ci-info": "^4.1.0",
                 "cli-columns": "^4.0.0",
                 "fastest-levenshtein": "^1.0.16",
                 "fs-minipass": "^3.0.3",
-                "glob": "^10.3.12",
+                "glob": "^10.4.5",
                 "graceful-fs": "^4.2.11",
-                "hosted-git-info": "^7.0.1",
-                "ini": "^4.1.2",
-                "init-package-json": "^6.0.2",
-                "is-cidr": "^5.0.5",
-                "json-parse-even-better-errors": "^3.0.1",
-                "libnpmaccess": "^8.0.1",
-                "libnpmdiff": "^6.0.3",
-                "libnpmexec": "^8.0.0",
-                "libnpmfund": "^5.0.1",
-                "libnpmhook": "^10.0.0",
-                "libnpmorg": "^6.0.1",
-                "libnpmpack": "^7.0.0",
-                "libnpmpublish": "^9.0.2",
-                "libnpmsearch": "^7.0.0",
-                "libnpmteam": "^6.0.0",
-                "libnpmversion": "^6.0.0",
-                "make-fetch-happen": "^13.0.1",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.0.4",
+                "hosted-git-info": "^8.0.2",
+                "ini": "^5.0.0",
+                "init-package-json": "^7.0.2",
+                "is-cidr": "^5.1.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "libnpmaccess": "^9.0.0",
+                "libnpmdiff": "^7.0.0",
+                "libnpmexec": "^9.0.0",
+                "libnpmfund": "^6.0.0",
+                "libnpmhook": "^11.0.0",
+                "libnpmorg": "^7.0.0",
+                "libnpmpack": "^8.0.0",
+                "libnpmpublish": "^10.0.1",
+                "libnpmsearch": "^8.0.0",
+                "libnpmteam": "^7.0.0",
+                "libnpmversion": "^7.0.0",
+                "make-fetch-happen": "^14.0.3",
+                "minimatch": "^9.0.5",
+                "minipass": "^7.1.1",
                 "minipass-pipeline": "^1.2.4",
                 "ms": "^2.1.2",
-                "node-gyp": "^10.1.0",
-                "nopt": "^7.2.0",
-                "normalize-package-data": "^6.0.0",
-                "npm-audit-report": "^5.0.0",
-                "npm-install-checks": "^6.3.0",
-                "npm-package-arg": "^11.0.2",
-                "npm-pick-manifest": "^9.0.0",
-                "npm-profile": "^9.0.2",
-                "npm-registry-fetch": "^17.0.0",
-                "npm-user-validate": "^2.0.0",
+                "node-gyp": "^11.0.0",
+                "nopt": "^8.0.0",
+                "normalize-package-data": "^7.0.0",
+                "npm-audit-report": "^6.0.0",
+                "npm-install-checks": "^7.1.1",
+                "npm-package-arg": "^12.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-profile": "^11.0.1",
+                "npm-registry-fetch": "^18.0.2",
+                "npm-user-validate": "^3.0.0",
                 "p-map": "^4.0.0",
-                "pacote": "^18.0.3",
-                "parse-conflict-json": "^3.0.1",
-                "proc-log": "^4.2.0",
+                "pacote": "^19.0.1",
+                "parse-conflict-json": "^4.0.0",
+                "proc-log": "^5.0.0",
                 "qrcode-terminal": "^0.12.0",
-                "read": "^3.0.1",
-                "semver": "^7.6.0",
+                "read": "^4.0.0",
+                "semver": "^7.6.3",
                 "spdx-expression-parse": "^4.0.0",
-                "ssri": "^10.0.5",
+                "ssri": "^12.0.0",
                 "supports-color": "^9.4.0",
                 "tar": "^6.2.1",
                 "text-table": "~0.2.0",
                 "tiny-relative-date": "^1.3.0",
                 "treeverse": "^3.0.0",
-                "validate-npm-package-name": "^5.0.0",
-                "which": "^4.0.0",
-                "write-file-atomic": "^5.0.1"
+                "validate-npm-package-name": "^6.0.0",
+                "which": "^5.0.0",
+                "write-file-atomic": "^6.0.0"
             },
             "bin": {
                 "npm": "bin/npm-cli.js",
@@ -3628,28 +3589,15 @@
             }
         },
         "node_modules/npm-run-path": {
-            "version": "5.3.0",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "path-key": "^4.0.0"
+                "path-key": "^3.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/npm/node_modules/@isaacs/cliui": {
@@ -3670,7 +3618,7 @@
             }
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-            "version": "6.0.1",
+            "version": "6.1.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -3719,6 +3667,18 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
             "dev": true,
@@ -3726,7 +3686,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/agent": {
-            "version": "2.2.2",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -3738,47 +3698,48 @@
                 "socks-proxy-agent": "^8.0.3"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
-            "version": "7.5.1",
+            "version": "8.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/fs": "^3.1.0",
-                "@npmcli/installed-package-contents": "^2.1.0",
-                "@npmcli/map-workspaces": "^3.0.2",
-                "@npmcli/metavuln-calculator": "^7.1.0",
-                "@npmcli/name-from-folder": "^2.0.0",
-                "@npmcli/node-gyp": "^3.0.0",
-                "@npmcli/package-json": "^5.1.0",
-                "@npmcli/query": "^3.1.0",
-                "@npmcli/redact": "^2.0.0",
-                "@npmcli/run-script": "^8.1.0",
-                "bin-links": "^4.0.1",
-                "cacache": "^18.0.0",
+                "@npmcli/fs": "^4.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "@npmcli/map-workspaces": "^4.0.1",
+                "@npmcli/metavuln-calculator": "^8.0.0",
+                "@npmcli/name-from-folder": "^3.0.0",
+                "@npmcli/node-gyp": "^4.0.0",
+                "@npmcli/package-json": "^6.0.1",
+                "@npmcli/query": "^4.0.0",
+                "@npmcli/redact": "^3.0.0",
+                "@npmcli/run-script": "^9.0.1",
+                "bin-links": "^5.0.0",
+                "cacache": "^19.0.1",
                 "common-ancestor-path": "^1.0.1",
-                "hosted-git-info": "^7.0.1",
-                "json-parse-even-better-errors": "^3.0.0",
+                "hosted-git-info": "^8.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
                 "json-stringify-nice": "^1.1.4",
+                "lru-cache": "^10.2.2",
                 "minimatch": "^9.0.4",
-                "nopt": "^7.0.0",
-                "npm-install-checks": "^6.2.0",
-                "npm-package-arg": "^11.0.2",
-                "npm-pick-manifest": "^9.0.0",
-                "npm-registry-fetch": "^17.0.0",
-                "pacote": "^18.0.1",
-                "parse-conflict-json": "^3.0.0",
-                "proc-log": "^4.2.0",
-                "proggy": "^2.0.0",
+                "nopt": "^8.0.0",
+                "npm-install-checks": "^7.1.0",
+                "npm-package-arg": "^12.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-registry-fetch": "^18.0.1",
+                "pacote": "^19.0.0",
+                "parse-conflict-json": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "proggy": "^3.0.0",
                 "promise-all-reject-late": "^1.0.0",
                 "promise-call-limit": "^3.0.1",
-                "read-package-json-fast": "^3.0.2",
+                "read-package-json-fast": "^4.0.0",
                 "semver": "^7.3.7",
-                "ssri": "^10.0.5",
+                "ssri": "^12.0.0",
                 "treeverse": "^3.0.0",
                 "walk-up-path": "^3.0.1"
             },
@@ -3786,30 +3747,30 @@
                 "arborist": "bin/index.js"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/config": {
-            "version": "8.3.1",
+            "version": "9.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/map-workspaces": "^3.0.2",
+                "@npmcli/map-workspaces": "^4.0.1",
+                "@npmcli/package-json": "^6.0.1",
                 "ci-info": "^4.0.0",
-                "ini": "^4.1.2",
-                "nopt": "^7.0.0",
-                "proc-log": "^4.2.0",
-                "read-package-json-fast": "^3.0.2",
+                "ini": "^5.0.0",
+                "nopt": "^8.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.5",
                 "walk-up-path": "^3.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/fs": {
-            "version": "3.1.0",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -3817,159 +3778,191 @@
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/git": {
-            "version": "5.0.6",
+            "version": "6.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/promise-spawn": "^7.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "ini": "^5.0.0",
                 "lru-cache": "^10.0.1",
-                "npm-pick-manifest": "^9.0.0",
-                "proc-log": "^4.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "proc-log": "^5.0.0",
                 "promise-inflight": "^1.0.1",
                 "promise-retry": "^2.0.1",
                 "semver": "^7.3.5",
-                "which": "^4.0.0"
+                "which": "^5.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-            "version": "2.1.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-bundled": "^3.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
+                "npm-bundled": "^4.0.0",
+                "npm-normalize-package-bin": "^4.0.0"
             },
             "bin": {
                 "installed-package-contents": "bin/index.js"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-            "version": "3.0.6",
+            "version": "4.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/name-from-folder": "^2.0.0",
+                "@npmcli/name-from-folder": "^3.0.0",
+                "@npmcli/package-json": "^6.0.0",
                 "glob": "^10.2.2",
-                "minimatch": "^9.0.0",
-                "read-package-json-fast": "^3.0.0"
+                "minimatch": "^9.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-            "version": "7.1.0",
+            "version": "8.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "cacache": "^18.0.0",
-                "json-parse-even-better-errors": "^3.0.0",
-                "pacote": "^18.0.0",
-                "proc-log": "^4.1.0",
+                "cacache": "^19.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "pacote": "^20.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-            "version": "2.0.0",
+        "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+            "version": "20.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^6.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "@npmcli/run-script": "^9.0.0",
+                "cacache": "^19.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^7.0.2",
+                "npm-package-arg": "^12.0.0",
+                "npm-packlist": "^9.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-registry-fetch": "^18.0.0",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1",
+                "sigstore": "^3.0.0",
+                "ssri": "^12.0.0",
+                "tar": "^6.1.11"
+            },
+            "bin": {
+                "pacote": "bin/index.js"
+            },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/npm/node_modules/@npmcli/node-gyp": {
+        "node_modules/npm/node_modules/@npmcli/name-from-folder": {
             "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/node-gyp": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/package-json": {
-            "version": "5.1.0",
+            "version": "6.1.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/git": "^5.0.0",
+                "@npmcli/git": "^6.0.0",
                 "glob": "^10.2.2",
-                "hosted-git-info": "^7.0.0",
-                "json-parse-even-better-errors": "^3.0.0",
-                "normalize-package-data": "^6.0.0",
-                "proc-log": "^4.0.0",
+                "hosted-git-info": "^8.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
+                "normalize-package-data": "^7.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.5.3"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-            "version": "7.0.1",
+            "version": "8.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "which": "^4.0.0"
+                "which": "^5.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/query": {
-            "version": "3.1.0",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "postcss-selector-parser": "^6.0.10"
+                "postcss-selector-parser": "^6.1.2"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/redact": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@npmcli/run-script": {
-            "version": "8.1.0",
+            "version": "9.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/node-gyp": "^3.0.0",
-                "@npmcli/package-json": "^5.0.0",
-                "@npmcli/promise-spawn": "^7.0.0",
-                "node-gyp": "^10.0.0",
-                "proc-log": "^4.0.0",
-                "which": "^4.0.0"
+                "@npmcli/node-gyp": "^4.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "node-gyp": "^11.0.0",
+                "proc-log": "^5.0.0",
+                "which": "^5.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@pkgjs/parseargs": {
@@ -3982,76 +3975,26 @@
                 "node": ">=14"
             }
         },
-        "node_modules/npm/node_modules/@sigstore/bundle": {
-            "version": "2.3.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@sigstore/protobuf-specs": "^0.3.1"
-            },
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/@sigstore/core": {
-            "version": "1.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-            "version": "0.3.1",
+            "version": "0.3.2",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/@sigstore/sign": {
-            "version": "2.3.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@sigstore/bundle": "^2.3.0",
-                "@sigstore/core": "^1.0.0",
-                "@sigstore/protobuf-specs": "^0.3.1",
-                "make-fetch-happen": "^13.0.0"
-            },
             "engines": {
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/@sigstore/tuf": {
-            "version": "2.3.2",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/protobuf-specs": "^0.3.0",
-                "tuf-js": "^2.2.0"
+                "@sigstore/protobuf-specs": "^0.3.2",
+                "tuf-js": "^3.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/@sigstore/verify": {
-            "version": "1.2.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@sigstore/bundle": "^2.3.1",
-                "@sigstore/core": "^1.1.0",
-                "@sigstore/protobuf-specs": "^0.3.1"
-            },
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -4063,26 +4006,13 @@
                 "node": "^16.14.0 || >=18.0.0"
             }
         },
-        "node_modules/npm/node_modules/@tufjs/models": {
-            "version": "2.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "@tufjs/canonical-json": "2.0.0",
-                "minimatch": "^9.0.3"
-            },
-            "engines": {
-                "node": "^16.14.0 || >=18.0.0"
-            }
-        },
         "node_modules/npm/node_modules/abbrev": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/agent-base": {
@@ -4150,18 +4080,19 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/bin-links": {
-            "version": "4.0.3",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "cmd-shim": "^6.0.0",
-                "npm-normalize-package-bin": "^3.0.0",
-                "read-cmd-shim": "^4.0.0",
-                "write-file-atomic": "^5.0.0"
+                "cmd-shim": "^7.0.0",
+                "npm-normalize-package-bin": "^4.0.0",
+                "proc-log": "^5.0.0",
+                "read-cmd-shim": "^5.0.0",
+                "write-file-atomic": "^6.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/binary-extensions": {
@@ -4185,22 +4116,13 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/npm/node_modules/builtins": {
-            "version": "5.1.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^7.0.0"
-            }
-        },
         "node_modules/npm/node_modules/cacache": {
-            "version": "18.0.2",
+            "version": "19.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/fs": "^3.1.0",
+                "@npmcli/fs": "^4.0.0",
                 "fs-minipass": "^3.0.0",
                 "glob": "^10.2.2",
                 "lru-cache": "^10.0.1",
@@ -4208,13 +4130,88 @@
                 "minipass-collect": "^2.0.1",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
+                "p-map": "^7.0.2",
+                "ssri": "^12.0.0",
+                "tar": "^7.4.3",
+                "unique-filename": "^4.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/cacache/node_modules/chownr": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.4",
+                "rimraf": "^5.0.5"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/cacache/node_modules/p-map": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/cacache/node_modules/tar": {
+            "version": "7.4.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.0.1",
+                "mkdirp": "^3.0.1",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/cacache/node_modules/yallist": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/npm/node_modules/chalk": {
@@ -4239,7 +4236,7 @@
             }
         },
         "node_modules/npm/node_modules/ci-info": {
-            "version": "4.0.0",
+            "version": "4.1.0",
             "dev": true,
             "funding": [
                 {
@@ -4254,7 +4251,7 @@
             }
         },
         "node_modules/npm/node_modules/cidr-regex": {
-            "version": "4.0.5",
+            "version": "4.1.1",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -4288,12 +4285,12 @@
             }
         },
         "node_modules/npm/node_modules/cmd-shim": {
-            "version": "6.0.2",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/color-convert": {
@@ -4321,7 +4318,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/cross-spawn": {
-            "version": "7.0.3",
+            "version": "7.0.6",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -4362,12 +4359,12 @@
             }
         },
         "node_modules/npm/node_modules/debug": {
-            "version": "4.3.4",
+            "version": "4.3.7",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -4377,12 +4374,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/npm/node_modules/debug/node_modules/ms": {
-            "version": "2.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
         },
         "node_modules/npm/node_modules/diff": {
             "version": "5.2.0",
@@ -4446,7 +4437,7 @@
             }
         },
         "node_modules/npm/node_modules/foreground-child": {
-            "version": "3.1.1",
+            "version": "3.3.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -4473,32 +4464,21 @@
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
-        "node_modules/npm/node_modules/function-bind": {
-            "version": "1.1.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/npm/node_modules/glob": {
-            "version": "10.3.12",
+            "version": "10.4.5",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "foreground-child": "^3.1.0",
-                "jackspeak": "^2.3.6",
-                "minimatch": "^9.0.1",
-                "minipass": "^7.0.4",
-                "path-scurry": "^1.10.2"
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
             },
             "bin": {
                 "glob": "dist/esm/bin.mjs"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -4510,20 +4490,8 @@
             "inBundle": true,
             "license": "ISC"
         },
-        "node_modules/npm/node_modules/hasown": {
-            "version": "2.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/npm/node_modules/hosted-git-info": {
-            "version": "7.0.1",
+            "version": "8.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -4531,7 +4499,7 @@
                 "lru-cache": "^10.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/http-cache-semantics": {
@@ -4554,7 +4522,7 @@
             }
         },
         "node_modules/npm/node_modules/https-proxy-agent": {
-            "version": "7.0.4",
+            "version": "7.0.5",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -4580,7 +4548,7 @@
             }
         },
         "node_modules/npm/node_modules/ignore-walk": {
-            "version": "6.0.4",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -4588,7 +4556,7 @@
                 "minimatch": "^9.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/imurmurhash": {
@@ -4610,30 +4578,30 @@
             }
         },
         "node_modules/npm/node_modules/ini": {
-            "version": "4.1.2",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/init-package-json": {
-            "version": "6.0.2",
+            "version": "7.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/package-json": "^5.0.0",
-                "npm-package-arg": "^11.0.0",
-                "promzard": "^1.0.0",
-                "read": "^3.0.1",
+                "@npmcli/package-json": "^6.0.0",
+                "npm-package-arg": "^12.0.0",
+                "promzard": "^2.0.0",
+                "read": "^4.0.0",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "^5.0.0"
+                "validate-npm-package-name": "^6.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/ip-address": {
@@ -4662,27 +4630,15 @@
             }
         },
         "node_modules/npm/node_modules/is-cidr": {
-            "version": "5.0.5",
+            "version": "5.1.0",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "cidr-regex": "^4.0.4"
+                "cidr-regex": "^4.1.1"
             },
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/npm/node_modules/is-core-module": {
-            "version": "2.13.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "hasown": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/npm/node_modules/is-fullwidth-code-point": {
@@ -4694,12 +4650,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/npm/node_modules/is-lambda": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT"
-        },
         "node_modules/npm/node_modules/isexe": {
             "version": "2.0.0",
             "dev": true,
@@ -4707,15 +4657,12 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/jackspeak": {
-            "version": "2.3.6",
+            "version": "3.4.3",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/cliui": "^8.0.2"
-            },
-            "engines": {
-                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -4731,12 +4678,12 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/json-parse-even-better-errors": {
-            "version": "3.0.1",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/json-stringify-nice": {
@@ -4770,205 +4717,210 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/libnpmaccess": {
-            "version": "8.0.5",
+            "version": "9.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-package-arg": "^11.0.2",
-                "npm-registry-fetch": "^17.0.0"
+                "npm-package-arg": "^12.0.0",
+                "npm-registry-fetch": "^18.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmdiff": {
-            "version": "6.1.1",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.2.1",
-                "@npmcli/installed-package-contents": "^2.1.0",
+                "@npmcli/arborist": "^8.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
                 "binary-extensions": "^2.3.0",
                 "diff": "^5.1.0",
                 "minimatch": "^9.0.4",
-                "npm-package-arg": "^11.0.2",
-                "pacote": "^18.0.1",
+                "npm-package-arg": "^12.0.0",
+                "pacote": "^19.0.0",
                 "tar": "^6.2.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmexec": {
-            "version": "8.1.0",
+            "version": "9.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.2.1",
-                "@npmcli/run-script": "^8.1.0",
+                "@npmcli/arborist": "^8.0.0",
+                "@npmcli/run-script": "^9.0.1",
                 "ci-info": "^4.0.0",
-                "npm-package-arg": "^11.0.2",
-                "pacote": "^18.0.1",
-                "proc-log": "^4.2.0",
-                "read": "^3.0.1",
-                "read-package-json-fast": "^3.0.2",
+                "npm-package-arg": "^12.0.0",
+                "pacote": "^19.0.0",
+                "proc-log": "^5.0.0",
+                "read": "^4.0.0",
+                "read-package-json-fast": "^4.0.0",
                 "semver": "^7.3.7",
                 "walk-up-path": "^3.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmfund": {
-            "version": "5.0.9",
+            "version": "6.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.2.1"
+                "@npmcli/arborist": "^8.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmhook": {
-            "version": "10.0.4",
+            "version": "11.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
-                "npm-registry-fetch": "^17.0.0"
+                "npm-registry-fetch": "^18.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmorg": {
-            "version": "6.0.5",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
-                "npm-registry-fetch": "^17.0.0"
+                "npm-registry-fetch": "^18.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmpack": {
-            "version": "7.0.1",
+            "version": "8.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/arborist": "^7.2.1",
-                "@npmcli/run-script": "^8.1.0",
-                "npm-package-arg": "^11.0.2",
-                "pacote": "^18.0.1"
+                "@npmcli/arborist": "^8.0.0",
+                "@npmcli/run-script": "^9.0.1",
+                "npm-package-arg": "^12.0.0",
+                "pacote": "^19.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmpublish": {
-            "version": "9.0.7",
+            "version": "10.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "ci-info": "^4.0.0",
-                "normalize-package-data": "^6.0.0",
-                "npm-package-arg": "^11.0.2",
-                "npm-registry-fetch": "^17.0.0",
-                "proc-log": "^4.2.0",
+                "normalize-package-data": "^7.0.0",
+                "npm-package-arg": "^12.0.0",
+                "npm-registry-fetch": "^18.0.1",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.7",
-                "sigstore": "^2.2.0",
-                "ssri": "^10.0.5"
+                "sigstore": "^3.0.0",
+                "ssri": "^12.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmsearch": {
-            "version": "7.0.4",
+            "version": "8.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-registry-fetch": "^17.0.0"
+                "npm-registry-fetch": "^18.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmteam": {
-            "version": "6.0.4",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
                 "aproba": "^2.0.0",
-                "npm-registry-fetch": "^17.0.0"
+                "npm-registry-fetch": "^18.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/libnpmversion": {
-            "version": "6.0.1",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/git": "^5.0.6",
-                "@npmcli/run-script": "^8.1.0",
-                "json-parse-even-better-errors": "^3.0.0",
-                "proc-log": "^4.2.0",
+                "@npmcli/git": "^6.0.1",
+                "@npmcli/run-script": "^9.0.1",
+                "json-parse-even-better-errors": "^4.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.7"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/lru-cache": {
-            "version": "10.2.2",
+            "version": "10.4.3",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
-            "engines": {
-                "node": "14 || >=16.14"
-            }
+            "license": "ISC"
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
-            "version": "13.0.1",
+            "version": "14.0.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/agent": "^2.0.0",
-                "cacache": "^18.0.0",
+                "@npmcli/agent": "^3.0.0",
+                "cacache": "^19.0.1",
                 "http-cache-semantics": "^4.1.1",
-                "is-lambda": "^1.0.1",
                 "minipass": "^7.0.2",
-                "minipass-fetch": "^3.0.0",
+                "minipass-fetch": "^4.0.0",
                 "minipass-flush": "^1.0.5",
                 "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "proc-log": "^4.2.0",
+                "negotiator": "^1.0.0",
+                "proc-log": "^5.0.0",
                 "promise-retry": "^2.0.1",
-                "ssri": "^10.0.0"
+                "ssri": "^12.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/npm/node_modules/minimatch": {
-            "version": "9.0.4",
+            "version": "9.0.5",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -4983,7 +4935,7 @@
             }
         },
         "node_modules/npm/node_modules/minipass": {
-            "version": "7.0.4",
+            "version": "7.1.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5004,20 +4956,33 @@
             }
         },
         "node_modules/npm/node_modules/minipass-fetch": {
-            "version": "3.0.4",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "minipass": "^7.0.3",
                 "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
+                "minizlib": "^3.0.1"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             },
             "optionalDependencies": {
                 "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.4",
+                "rimraf": "^5.0.5"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/npm/node_modules/minipass-flush": {
@@ -5033,28 +4998,6 @@
             }
         },
         "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-            "version": "3.3.6",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-json-stream": {
-            "version": "1.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "dependencies": {
-                "jsonparse": "^1.3.1",
-                "minipass": "^3.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
             "version": "3.3.6",
             "dev": true,
             "inBundle": true,
@@ -5158,25 +5101,16 @@
             "license": "MIT"
         },
         "node_modules/npm/node_modules/mute-stream": {
-            "version": "1.0.0",
+            "version": "2.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/negotiator": {
-            "version": "0.6.3",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/node-gyp": {
-            "version": "10.1.0",
+            "version": "11.0.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -5185,31 +5119,85 @@
                 "exponential-backoff": "^3.1.1",
                 "glob": "^10.3.10",
                 "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^13.0.0",
-                "nopt": "^7.0.0",
-                "proc-log": "^3.0.0",
+                "make-fetch-happen": "^14.0.3",
+                "nopt": "^8.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^4.0.0"
+                "tar": "^7.4.3",
+                "which": "^5.0.0"
             },
             "bin": {
                 "node-gyp": "bin/node-gyp.js"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
+        "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
             "version": "3.0.0",
             "dev": true,
             "inBundle": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp/node_modules/minizlib": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.4",
+                "rimraf": "^5.0.5"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "mkdirp": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
+            "version": "7.4.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.0.1",
+                "mkdirp": "^3.0.1",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/npm/node_modules/nopt": {
-            "version": "7.2.0",
+            "version": "8.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5220,47 +5208,55 @@
                 "nopt": "bin/nopt.js"
             },
             "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/nopt/node_modules/abbrev": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/npm/node_modules/normalize-package-data": {
-            "version": "6.0.0",
+            "version": "7.0.0",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "hosted-git-info": "^7.0.0",
-                "is-core-module": "^2.8.1",
+                "hosted-git-info": "^8.0.0",
                 "semver": "^7.3.5",
                 "validate-npm-package-license": "^3.0.4"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-audit-report": {
-            "version": "5.0.0",
+            "version": "6.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-bundled": {
-            "version": "3.0.0",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-normalize-package-bin": "^3.0.0"
+                "npm-normalize-package-bin": "^4.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-install-checks": {
-            "version": "6.3.0",
+            "version": "7.1.1",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
@@ -5268,99 +5264,112 @@
                 "semver": "^7.1.1"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-normalize-package-bin": {
-            "version": "3.0.1",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-package-arg": {
-            "version": "11.0.2",
+            "version": "12.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "hosted-git-info": "^7.0.0",
-                "proc-log": "^4.0.0",
+                "hosted-git-info": "^8.0.0",
+                "proc-log": "^5.0.0",
                 "semver": "^7.3.5",
-                "validate-npm-package-name": "^5.0.0"
+                "validate-npm-package-name": "^6.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-packlist": {
-            "version": "8.0.2",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "ignore-walk": "^6.0.4"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/npm-pick-manifest": {
             "version": "9.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-install-checks": "^6.0.0",
-                "npm-normalize-package-bin": "^3.0.0",
-                "npm-package-arg": "^11.0.0",
+                "ignore-walk": "^7.0.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-pick-manifest": {
+            "version": "10.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^7.1.0",
+                "npm-normalize-package-bin": "^4.0.0",
+                "npm-package-arg": "^12.0.0",
                 "semver": "^7.3.5"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-profile": {
-            "version": "9.0.2",
+            "version": "11.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "npm-registry-fetch": "^17.0.0",
-                "proc-log": "^4.0.0"
+                "npm-registry-fetch": "^18.0.0",
+                "proc-log": "^5.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
-            "version": "17.0.0",
+            "version": "18.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/redact": "^2.0.0",
-                "make-fetch-happen": "^13.0.0",
+                "@npmcli/redact": "^3.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^14.0.0",
                 "minipass": "^7.0.2",
-                "minipass-fetch": "^3.0.0",
-                "minipass-json-stream": "^1.0.1",
-                "minizlib": "^2.1.2",
-                "npm-package-arg": "^11.0.0",
-                "proc-log": "^4.0.0"
+                "minipass-fetch": "^4.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^12.0.0",
+                "proc-log": "^5.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.4",
+                "rimraf": "^5.0.5"
+            },
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/npm/node_modules/npm-user-validate": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/p-map": {
@@ -5378,49 +5387,55 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/npm/node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0"
+        },
         "node_modules/npm/node_modules/pacote": {
-            "version": "18.0.3",
+            "version": "19.0.1",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "@npmcli/git": "^5.0.0",
-                "@npmcli/installed-package-contents": "^2.0.1",
-                "@npmcli/package-json": "^5.1.0",
-                "@npmcli/promise-spawn": "^7.0.0",
-                "@npmcli/run-script": "^8.0.0",
-                "cacache": "^18.0.0",
+                "@npmcli/git": "^6.0.0",
+                "@npmcli/installed-package-contents": "^3.0.0",
+                "@npmcli/package-json": "^6.0.0",
+                "@npmcli/promise-spawn": "^8.0.0",
+                "@npmcli/run-script": "^9.0.0",
+                "cacache": "^19.0.0",
                 "fs-minipass": "^3.0.0",
                 "minipass": "^7.0.2",
-                "npm-package-arg": "^11.0.0",
-                "npm-packlist": "^8.0.0",
-                "npm-pick-manifest": "^9.0.0",
-                "npm-registry-fetch": "^17.0.0",
-                "proc-log": "^4.0.0",
+                "npm-package-arg": "^12.0.0",
+                "npm-packlist": "^9.0.0",
+                "npm-pick-manifest": "^10.0.0",
+                "npm-registry-fetch": "^18.0.0",
+                "proc-log": "^5.0.0",
                 "promise-retry": "^2.0.1",
-                "sigstore": "^2.2.0",
-                "ssri": "^10.0.0",
+                "sigstore": "^3.0.0",
+                "ssri": "^12.0.0",
                 "tar": "^6.1.11"
             },
             "bin": {
-                "pacote": "lib/bin.js"
+                "pacote": "bin/index.js"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/parse-conflict-json": {
-            "version": "3.0.1",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0",
+                "json-parse-even-better-errors": "^4.0.0",
                 "just-diff": "^6.0.0",
                 "just-diff-apply": "^5.2.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/path-key": {
@@ -5433,7 +5448,7 @@
             }
         },
         "node_modules/npm/node_modules/path-scurry": {
-            "version": "1.10.2",
+            "version": "1.11.1",
             "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
@@ -5442,14 +5457,14 @@
                 "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": ">=16 || 14 >=14.18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/npm/node_modules/postcss-selector-parser": {
-            "version": "6.0.16",
+            "version": "6.1.2",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -5462,21 +5477,21 @@
             }
         },
         "node_modules/npm/node_modules/proc-log": {
-            "version": "4.2.0",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/proggy": {
-            "version": "2.0.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -5489,7 +5504,7 @@
             }
         },
         "node_modules/npm/node_modules/promise-call-limit": {
-            "version": "3.0.1",
+            "version": "3.0.2",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5517,15 +5532,15 @@
             }
         },
         "node_modules/npm/node_modules/promzard": {
-            "version": "1.0.1",
+            "version": "2.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "read": "^3.0.1"
+                "read": "^4.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/qrcode-terminal": {
@@ -5537,37 +5552,37 @@
             }
         },
         "node_modules/npm/node_modules/read": {
-            "version": "3.0.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "mute-stream": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
-        "node_modules/npm/node_modules/read-cmd-shim": {
             "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
+            "dependencies": {
+                "mute-stream": "^2.0.0"
+            },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/read-cmd-shim": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/read-package-json-fast": {
-            "version": "3.0.2",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "json-parse-even-better-errors": "^3.0.0",
-                "npm-normalize-package-bin": "^3.0.0"
+                "json-parse-even-better-errors": "^4.0.0",
+                "npm-normalize-package-bin": "^4.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/retry": {
@@ -5579,6 +5594,21 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/npm/node_modules/rimraf": {
+            "version": "5.0.10",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "glob": "^10.3.7"
+            },
+            "bin": {
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/npm/node_modules/safer-buffer": {
             "version": "2.1.2",
             "dev": true,
@@ -5587,27 +5617,12 @@
             "optional": true
         },
         "node_modules/npm/node_modules/semver": {
-            "version": "7.6.0",
+            "version": "7.6.3",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -5647,20 +5662,72 @@
             }
         },
         "node_modules/npm/node_modules/sigstore": {
-            "version": "2.3.0",
+            "version": "3.0.0",
             "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@sigstore/bundle": "^2.3.1",
-                "@sigstore/core": "^1.0.0",
-                "@sigstore/protobuf-specs": "^0.3.1",
-                "@sigstore/sign": "^2.3.0",
-                "@sigstore/tuf": "^2.3.1",
-                "@sigstore/verify": "^1.2.0"
+                "@sigstore/bundle": "^3.0.0",
+                "@sigstore/core": "^2.0.0",
+                "@sigstore/protobuf-specs": "^0.3.2",
+                "@sigstore/sign": "^3.0.0",
+                "@sigstore/tuf": "^3.0.0",
+                "@sigstore/verify": "^2.0.0"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.3.2"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^3.0.0",
+                "@sigstore/core": "^2.0.0",
+                "@sigstore/protobuf-specs": "^0.3.2",
+                "make-fetch-happen": "^14.0.1",
+                "proc-log": "^5.0.0",
+                "promise-retry": "^2.0.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^3.0.0",
+                "@sigstore/core": "^2.0.0",
+                "@sigstore/protobuf-specs": "^0.3.2"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/smart-buffer": {
@@ -5688,14 +5755,14 @@
             }
         },
         "node_modules/npm/node_modules/socks-proxy-agent": {
-            "version": "8.0.3",
+            "version": "8.0.4",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.1",
                 "debug": "^4.3.4",
-                "socks": "^2.7.1"
+                "socks": "^2.8.3"
             },
             "engines": {
                 "node": ">= 14"
@@ -5738,7 +5805,7 @@
             }
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
-            "version": "3.0.17",
+            "version": "3.0.20",
             "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
@@ -5750,7 +5817,7 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/npm/node_modules/ssri": {
-            "version": "10.0.5",
+            "version": "12.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5758,7 +5825,7 @@
                 "minipass": "^7.0.3"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/string-width": {
@@ -5899,33 +5966,46 @@
             }
         },
         "node_modules/npm/node_modules/tuf-js": {
-            "version": "2.2.0",
+            "version": "3.0.1",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
-                "@tufjs/models": "2.0.0",
-                "debug": "^4.3.4",
-                "make-fetch-happen": "^13.0.0"
+                "@tufjs/models": "3.0.1",
+                "debug": "^4.3.6",
+                "make-fetch-happen": "^14.0.1"
             },
             "engines": {
-                "node": "^16.14.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "2.0.0",
+                "minimatch": "^9.0.5"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/unique-filename": {
-            "version": "3.0.0",
+            "version": "4.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
-                "unique-slug": "^4.0.0"
+                "unique-slug": "^5.0.0"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/unique-slug": {
-            "version": "4.0.0",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5933,7 +6013,7 @@
                 "imurmurhash": "^0.1.4"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/util-deprecate": {
@@ -5963,15 +6043,12 @@
             }
         },
         "node_modules/npm/node_modules/validate-npm-package-name": {
-            "version": "5.0.0",
+            "version": "6.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
-            "dependencies": {
-                "builtins": "^5.0.0"
-            },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/walk-up-path": {
@@ -5981,7 +6058,7 @@
             "license": "ISC"
         },
         "node_modules/npm/node_modules/which": {
-            "version": "4.0.0",
+            "version": "5.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -5992,7 +6069,7 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/which/node_modules/isexe": {
@@ -6055,7 +6132,7 @@
             }
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-            "version": "6.0.1",
+            "version": "6.1.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -6105,7 +6182,7 @@
             }
         },
         "node_modules/npm/node_modules/write-file-atomic": {
-            "version": "5.0.1",
+            "version": "6.0.0",
             "dev": true,
             "inBundle": true,
             "license": "ISC",
@@ -6114,7 +6191,7 @@
                 "signal-exit": "^4.0.1"
             },
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^18.17.0 || >=20.5.0"
             }
         },
         "node_modules/npm/node_modules/yallist": {
@@ -6125,76 +6202,47 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/object-inspect": {
-            "version": "1.13.1",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.assign": {
-            "version": "4.1.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "define-properties": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dependencies": {
                 "wrappy": "1"
             }
         },
         "node_modules/onetime": {
-            "version": "6.0.0",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "mimic-fn": "^4.0.0"
+                "mimic-fn": "^2.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "license": "MIT",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -6202,8 +6250,9 @@
         },
         "node_modules/p-each-series": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+            "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -6213,8 +6262,9 @@
         },
         "node_modules/p-filter": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+            "integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-map": "^7.0.1"
             },
@@ -6227,15 +6277,17 @@
         },
         "node_modules/p-is-promise": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+            "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -6248,7 +6300,8 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -6260,9 +6313,10 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.2",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+            "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6271,27 +6325,33 @@
             }
         },
         "node_modules/p-reduce": {
-            "version": "3.0.0",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+            "integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=8"
             }
         },
         "node_modules/p-try": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -6301,8 +6361,9 @@
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
@@ -6318,8 +6379,9 @@
         },
         "node_modules/parse-ms": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+            "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6329,64 +6391,93 @@
         },
         "node_modules/parse5": {
             "version": "5.1.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+            "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+            "dev": true
         },
         "node_modules/parse5-htmlparser2-tree-adapter": {
             "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+            "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "parse5": "^6.0.1"
             }
         },
         "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
             "version": "6.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+            "dev": true
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/path-to-regexp": {
-            "version": "6.2.1",
+        "node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
             "dev": true,
-            "license": "MIT"
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+            "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/path-type": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "engines": {
                 "node": ">=8.6"
             },
@@ -6396,16 +6487,18 @@
         },
         "node_modules/pify": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/pkg-conf": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+            "integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "find-up": "^2.0.0",
                 "load-json-file": "^4.0.0"
@@ -6416,8 +6509,9 @@
         },
         "node_modules/pkg-conf/node_modules/find-up": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+            "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "locate-path": "^2.0.0"
             },
@@ -6427,8 +6521,9 @@
         },
         "node_modules/pkg-conf/node_modules/locate-path": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-locate": "^2.0.0",
                 "path-exists": "^3.0.0"
@@ -6439,8 +6534,9 @@
         },
         "node_modules/pkg-conf/node_modules/p-limit": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-try": "^1.0.0"
             },
@@ -6450,8 +6546,9 @@
         },
         "node_modules/pkg-conf/node_modules/p-locate": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "p-limit": "^1.1.0"
             },
@@ -6461,31 +6558,26 @@
         },
         "node_modules/pkg-conf/node_modules/path-exists": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "engines": {
                 "node": ">= 0.8.0"
             }
         },
         "node_modules/prettier": {
-            "version": "3.2.5",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -6497,9 +6589,10 @@
             }
         },
         "node_modules/pretty-ms": {
-            "version": "9.0.0",
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
+            "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "parse-ms": "^4.0.0"
             },
@@ -6512,31 +6605,37 @@
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/propagate": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+            "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/proto-list": {
             "version": "1.2.4",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "funding": [
                 {
                     "type": "github",
@@ -6550,21 +6649,22 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "license": "MIT"
+            ]
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
             }
         },
         "node_modules/rc": {
             "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
-            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -6577,16 +6677,18 @@
         },
         "node_modules/rc/node_modules/strip-json-comments": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/read-package-up": {
             "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+            "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "find-up-simple": "^1.0.0",
                 "read-pkg": "^9.0.0",
@@ -6600,9 +6702,10 @@
             }
         },
         "node_modules/read-package-up/node_modules/type-fest": {
-            "version": "4.18.1",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
+            "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
             },
@@ -6612,8 +6715,9 @@
         },
         "node_modules/read-pkg": {
             "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+            "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.3",
                 "normalize-package-data": "^6.0.0",
@@ -6628,37 +6732,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/read-pkg-up": {
-            "version": "11.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "find-up-simple": "^1.0.0",
-                "read-pkg": "^9.0.0",
-                "type-fest": "^4.6.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/type-fest": {
-            "version": "4.18.3",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/read-pkg/node_modules/parse-json": {
             "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+            "integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.22.13",
                 "index-to-position": "^0.1.2",
@@ -6672,9 +6750,10 @@
             }
         },
         "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "4.18.1",
+            "version": "4.32.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
+            "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
             },
@@ -6684,8 +6763,9 @@
         },
         "node_modules/readable-stream": {
             "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -6696,15 +6776,11 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "node_modules/readable-stream/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/readdirp": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
             },
@@ -6712,27 +6788,11 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "set-function-name": "^2.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/registry-auth-token": {
-            "version": "5.0.2",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.3.tgz",
+            "integrity": "sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@pnpm/npm-conf": "^2.1.0"
             },
@@ -6742,22 +6802,25 @@
         },
         "node_modules/require-directory": {
             "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/reusify": {
             "version": "1.0.4",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -6765,14 +6828,17 @@
         },
         "node_modules/rewire": {
             "version": "7.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/rewire/-/rewire-7.0.0.tgz",
+            "integrity": "sha512-DyyNyzwMtGYgu0Zl/ya0PR/oaunM+VuCuBxCuhYJHHaV0V+YvYa3bBGxb5OZ71vndgmp1pYY8F4YOwQo1siRGw==",
             "dependencies": {
                 "eslint": "^8.47.0"
             }
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -6785,7 +6851,8 @@
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
             "version": "1.1.11",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6793,7 +6860,9 @@
         },
         "node_modules/rimraf/node_modules/glob": {
             "version": "7.2.3",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -6811,7 +6880,8 @@
         },
         "node_modules/rimraf/node_modules/minimatch": {
             "version": "3.1.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -6821,6 +6891,8 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "funding": [
                 {
                     "type": "github",
@@ -6835,76 +6907,25 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/safe-array-concat": {
-            "version": "1.1.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4",
-                "has-symbols": "^1.0.3",
-                "isarray": "^2.0.5"
-            },
-            "engines": {
-                "node": ">=0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-array-concat/node_modules/isarray": {
-            "version": "2.0.5",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/safe-regex-test": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.6",
-                "es-errors": "^1.3.0",
-                "is-regex": "^1.1.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/semantic-release": {
-            "version": "24.0.0",
+            "version": "24.2.1",
+            "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-24.2.1.tgz",
+            "integrity": "sha512-z0/3cutKNkLQ4Oy0HTi3lubnjTsdjjgOqmxdPjeYWe6lhFqUPfwslZxRHv3HDZlN4MhnZitb9SLihDkZNxOXfQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
                 "@semantic-release/error": "^4.0.0",
-                "@semantic-release/github": "^10.0.0",
+                "@semantic-release/github": "^11.0.0",
                 "@semantic-release/npm": "^12.0.0",
                 "@semantic-release/release-notes-generator": "^14.0.0-beta.1",
                 "aggregate-error": "^5.0.0",
@@ -6917,8 +6938,8 @@
                 "get-stream": "^6.0.0",
                 "git-log-parser": "^1.2.0",
                 "hook-std": "^3.0.0",
-                "hosted-git-info": "^7.0.0",
-                "import-from-esm": "^1.3.1",
+                "hosted-git-info": "^8.0.0",
+                "import-from-esm": "^2.0.0",
                 "lodash-es": "^4.17.21",
                 "marked": "^12.0.0",
                 "marked-terminal": "^7.0.0",
@@ -6945,8 +6966,9 @@
         },
         "node_modules/semantic-release/node_modules/@sindresorhus/merge-streams": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+            "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -6954,10 +6976,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/semantic-release/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/semantic-release/node_modules/cliui": {
             "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.1",
@@ -6967,26 +6999,33 @@
                 "node": ">=12"
             }
         },
+        "node_modules/semantic-release/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
         "node_modules/semantic-release/node_modules/execa": {
-            "version": "9.1.0",
+            "version": "9.5.2",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+            "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/merge-streams": "^4.0.0",
                 "cross-spawn": "^7.0.3",
                 "figures": "^6.1.0",
                 "get-stream": "^9.0.0",
-                "human-signals": "^7.0.0",
+                "human-signals": "^8.0.0",
                 "is-plain-obj": "^4.1.0",
                 "is-stream": "^4.0.1",
-                "npm-run-path": "^5.2.0",
+                "npm-run-path": "^6.0.0",
                 "pretty-ms": "^9.0.0",
                 "signal-exit": "^4.1.0",
                 "strip-final-newline": "^4.0.0",
                 "yoctocolors": "^2.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": "^18.19.0 || >=20.5.0"
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -6994,8 +7033,9 @@
         },
         "node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
             "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+            "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@sec-ant/readable-stream": "^0.4.1",
                 "is-stream": "^4.0.1"
@@ -7008,17 +7048,19 @@
             }
         },
         "node_modules/semantic-release/node_modules/human-signals": {
-            "version": "7.0.0",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
+            "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
             "dev": true,
-            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/semantic-release/node_modules/is-plain-obj": {
             "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -7028,10 +7070,51 @@
         },
         "node_modules/semantic-release/node_modules/is-stream": {
             "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+            "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/npm-run-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+            "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^4.0.0",
+                "unicorn-magic": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/p-reduce": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+            "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -7039,16 +7122,56 @@
         },
         "node_modules/semantic-release/node_modules/resolve-from": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
-            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/semantic-release/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/semantic-release/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/semantic-release/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/semantic-release/node_modules/strip-final-newline": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+            "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -7056,10 +7179,40 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/semantic-release/node_modules/unicorn-magic": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/semantic-release/node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/semantic-release/node_modules/yargs": {
             "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
@@ -7075,19 +7228,18 @@
         },
         "node_modules/semantic-release/node_modules/yargs-parser": {
             "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
         },
         "node_modules/semver": {
-            "version": "7.6.0",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -7097,8 +7249,9 @@
         },
         "node_modules/semver-diff": {
             "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+            "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -7111,8 +7264,9 @@
         },
         "node_modules/semver-regex": {
             "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+            "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -7120,58 +7274,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/serialize-javascript": {
-            "version": "6.0.0",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
         },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-function-name": {
-            "version": "2.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -7181,43 +7296,23 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/side-channel": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "object-inspect": "^1.13.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/signal-exit": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true
         },
         "node_modules/signale": {
             "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+            "integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "chalk": "^2.3.2",
                 "figures": "^2.0.0",
@@ -7229,8 +7324,9 @@
         },
         "node_modules/signale/node_modules/ansi-styles": {
             "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -7240,8 +7336,9 @@
         },
         "node_modules/signale/node_modules/chalk": {
             "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -7253,29 +7350,33 @@
         },
         "node_modules/signale/node_modules/color-convert": {
             "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "color-name": "1.1.3"
             }
         },
         "node_modules/signale/node_modules/color-name": {
             "version": "1.1.3",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
         },
         "node_modules/signale/node_modules/escape-string-regexp": {
             "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/signale/node_modules/figures": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "escape-string-regexp": "^1.0.5"
             },
@@ -7285,16 +7386,18 @@
         },
         "node_modules/signale/node_modules/has-flag": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/signale/node_modules/supports-color": {
             "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -7303,15 +7406,16 @@
             }
         },
         "node_modules/sinon": {
-            "version": "17.0.1",
+            "version": "19.0.2",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-19.0.2.tgz",
+            "integrity": "sha512-euuToqM+PjO4UgXeLETsfQiuoyPXlqFezr6YZDFwHR3t4qaX0fZUe1MfPMznTL5f8BWrVS89KduLdMUsxFCO6g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "dependencies": {
-                "@sinonjs/commons": "^3.0.0",
-                "@sinonjs/fake-timers": "^11.2.2",
-                "@sinonjs/samsam": "^8.0.0",
-                "diff": "^5.1.0",
-                "nise": "^5.1.5",
+                "@sinonjs/commons": "^3.0.1",
+                "@sinonjs/fake-timers": "^13.0.2",
+                "@sinonjs/samsam": "^8.0.1",
+                "diff": "^7.0.0",
+                "nise": "^6.1.1",
                 "supports-color": "^7.2.0"
             },
             "funding": {
@@ -7319,10 +7423,32 @@
                 "url": "https://opencollective.com/sinon"
             }
         },
+        "node_modules/sinon/node_modules/diff": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+            "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/sinon/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/skin-tone": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+            "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "unicode-emoji-modifier-base": "^1.0.0"
             },
@@ -7332,8 +7458,9 @@
         },
         "node_modules/slash": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             },
@@ -7343,21 +7470,24 @@
         },
         "node_modules/source-map": {
             "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/spawn-error-forwarder": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+            "integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+            "dev": true
         },
         "node_modules/spdx-correct": {
             "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-expression-parse": "^3.0.0",
                 "spdx-license-ids": "^3.0.0"
@@ -7365,27 +7495,40 @@
         },
         "node_modules/spdx-exceptions": {
             "version": "2.5.0",
-            "dev": true,
-            "license": "CC-BY-3.0"
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true
         },
         "node_modules/spdx-expression-parse": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "spdx-exceptions": "^2.1.0",
                 "spdx-license-ids": "^3.0.0"
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.17",
+            "version": "3.0.20",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
+            "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+            "dev": true
+        },
+        "node_modules/split2": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+            "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
             "dev": true,
-            "license": "CC0-1.0"
+            "dependencies": {
+                "through2": "~2.0.0"
+            }
         },
         "node_modules/stream-combiner2": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "duplexer2": "~0.1.0",
                 "readable-stream": "^2.0.2"
@@ -7393,21 +7536,36 @@
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.1.2",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/string-width": {
-            "version": "4.2.3",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -7417,55 +7575,26 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string.prototype.trim": {
-            "version": "1.2.9",
+        "node_modules/string-width-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.0",
-                "es-object-atoms": "^1.0.0"
-            },
             "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=8"
             }
         },
-        "node_modules/string.prototype.trimend": {
-            "version": "1.0.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+        "node_modules/string-width-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
-        "node_modules/string.prototype.trimstart": {
-            "version": "1.0.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/strip-ansi": {
+        "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -7473,28 +7602,65 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-bom": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/strip-final-newline": {
-            "version": "3.0.0",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "node": ">=6"
             }
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "engines": {
                 "node": ">=8"
             },
@@ -7504,8 +7670,9 @@
         },
         "node_modules/super-regex": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
+            "integrity": "sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "function-timeout": "^1.0.1",
                 "time-span": "^5.1.0"
@@ -7518,8 +7685,41 @@
             }
         },
         "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/supports-hyperlinks": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz",
+            "integrity": "sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/supports-hyperlinks/node_modules/supports-color": {
             "version": "7.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -7527,30 +7727,20 @@
                 "node": ">=8"
             }
         },
-        "node_modules/supports-hyperlinks": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0",
-                "supports-color": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=14.18"
-            }
-        },
         "node_modules/temp-dir": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+            "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.16"
             }
         },
         "node_modules/tempy": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+            "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "is-stream": "^3.0.0",
                 "temp-dir": "^3.0.0",
@@ -7564,10 +7754,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/tempy/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/tempy/node_modules/type-fest": {
             "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "dev": true,
-            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=12.20"
             },
@@ -7577,20 +7780,23 @@
         },
         "node_modules/text-table": {
             "version": "0.2.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
         },
         "node_modules/thenify": {
             "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0"
             }
         },
         "node_modules/thenify-all": {
             "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "thenify": ">= 3.1.0 < 4"
             },
@@ -7600,8 +7806,9 @@
         },
         "node_modules/through2": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
@@ -7609,8 +7816,9 @@
         },
         "node_modules/time-span": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+            "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "convert-hrtime": "^5.0.0"
             },
@@ -7633,14 +7841,10 @@
             }
         },
         "node_modules/traverse": {
-            "version": "0.6.9",
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+            "integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "gopd": "^1.0.1",
-                "typedarray.prototype.slice": "^1.0.3",
-                "which-typed-array": "^1.1.15"
-            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7650,14 +7854,16 @@
         },
         "node_modules/ts-mockito": {
             "version": "2.6.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.6.1.tgz",
+            "integrity": "sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==",
             "dependencies": {
                 "lodash": "^4.17.5"
             }
         },
         "node_modules/type-check": {
             "version": "0.4.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -7667,15 +7873,17 @@
         },
         "node_modules/type-detect": {
             "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/type-fest": {
             "version": "0.20.2",
-            "license": "(MIT OR CC0-1.0)",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "engines": {
                 "node": ">=10"
             },
@@ -7683,98 +7891,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/typed-array-byte-length": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-byte-offset": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-length": {
-            "version": "1.0.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13",
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typedarray.prototype.slice": {
-            "version": "1.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.0",
-                "es-errors": "^1.3.0",
-                "typed-array-buffer": "^1.0.2",
-                "typed-array-byte-offset": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/uglify-js": {
-            "version": "3.17.4",
+            "version": "3.19.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+            "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
@@ -7783,32 +7904,20 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/unbox-primitive": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-bigints": "^1.0.2",
-                "has-symbols": "^1.0.3",
-                "which-boxed-primitive": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/unicode-emoji-modifier-base": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+            "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/unicorn-magic": {
             "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -7818,8 +7927,9 @@
         },
         "node_modules/unique-string": {
             "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+            "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "crypto-random-string": "^4.0.0"
             },
@@ -7832,41 +7942,47 @@
         },
         "node_modules/universal-user-agent": {
             "version": "7.0.2",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+            "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+            "dev": true
         },
         "node_modules/universalify": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
         },
         "node_modules/url-join": {
             "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+            "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
@@ -7874,14 +7990,16 @@
         },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "license": "ISC",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -7892,53 +8010,49 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/which-boxed-primitive": {
-            "version": "1.0.2",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.15",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.2"
-            },
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
             "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/wordwrap": {
             "version": "1.0.0",
-            "dev": true,
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+            "dev": true
         },
         "node_modules/workerpool": {
-            "version": "6.2.1",
-            "dev": true,
-            "license": "Apache-2.0"
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+            "dev": true
         },
         "node_modules/wrap-ansi": {
-            "version": "7.0.0",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.0.0",
                 "string-width": "^4.1.0",
@@ -7951,35 +8065,87 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/xtend": {
             "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.4"
             }
         },
         "node_modules/y18n": {
             "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/yargs": {
             "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -7994,17 +8160,19 @@
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.4",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/yargs-unparser": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.0.0",
                 "decamelize": "^4.0.0",
@@ -8015,9 +8183,51 @@
                 "node": ">=10"
             }
         },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "engines": {
                 "node": ">=10"
             },
@@ -8026,9 +8236,10 @@
             }
         },
         "node_modules/yoctocolors": {
-            "version": "2.0.2",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
+            "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
         "start": "node index.js"
     },
     "type": "module",
+    "engines": {
+		"node": "^21.6.2",
+		"npm": ">=10.2.4"
+	},
     "repository": "github:centralnicgroup-opensource/rtldev-middleware-semantic-release-notify-plugin.git",
     "keywords": [],
     "maintainers": [
@@ -24,12 +28,12 @@
     "devDependencies": {
         "@semantic-release/changelog": "github:semantic-release/changelog",
         "@semantic-release/git": "github:semantic-release/git",
-        "mocha": "^10.4.0",
+        "mocha": "^11.0.1",
         "nock": "^13.5.4",
         "prettier": "^3.2.5",
         "semantic-release": "^24.0.0",
         "semantic-release-teams-notify-plugin": "file:./index.js",
-        "sinon": "^17.0.1"
+        "sinon": "^19.0.2"
     },
     "dependencies": {
         "@semantic-release/error": "^4.0.0",


### PR DESCRIPTION
…es setting to package.json

@AsifNawaz-cnic 

Ok, got it how tests work... Notifications still work and tests completed successfully while the node matrix used in our workflow also supports older versions of nodejs which are no longer compatible with the latest major versions of mocha/sinon.

`npx installed-check --engine-check --verbose`  asked me to add engines.node and to set `^21.6.2` (just fyi)

We still test for node 20 (bad engine error), but tests still complete successfully, so let us ignore that part.